### PR TITLE
fix "Usage:" in help

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ sudo chmod +x /usr/local/bin/kubelift
 
 ```bash
 kubelift --help
-Usage: kubelift [operation] [options...]
+Usage: kubelift <operation> [options...]
 Operations:
     create                                  Create a new Kubernetes cluster
     upgrade                                 Upgrade an existing Kubernetes cluster

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ sudo chmod +x /usr/local/bin/kubelift
 
 ```bash
 kubelift --help
-Usage: /usr/local/bin/kubelift [operation] [options...]
+Usage: kubelift [operation] [options...]
 Operations:
     create                                  Create a new Kubernetes cluster
     upgrade                                 Upgrade an existing Kubernetes cluster

--- a/kubelift.sh
+++ b/kubelift.sh
@@ -14,7 +14,7 @@ NUKE=false
 
 function print_usage() {
     cat << EOF
-Usage: $0 [operation] [options...]
+Usage: $(basename "$0") <operation> [options]
 Operations:
     create                                  Create a new Kubernetes cluster
     upgrade                                 Upgrade an existing Kubernetes cluster


### PR DESCRIPTION
current behavior:
```bash
kubelift --help
Usage: /usr/local/bin/kubelift [operation] [options...]
```

desired behavior:
```bash
kubelift --help
Usage: kubelift [operation] [options...]
```